### PR TITLE
feat: connect to the real database

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment
+DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,3 +1,6 @@
 # Tests
 
 I have opted to only implement E2E tests in the interest of time. Given a real project, I would like to see a mix unit, integration, and E2E.
+
+Having a 'fake' data source would actually be really useful for fast and determinstic testing. I would revisit introducing a system to
+use the in memory list of advocates from the seed directory for testing.

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,8 @@
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
 
 export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
-
-  const data = advocateData;
+  const data = await db.select().from(advocates);
 
   return Response.json({ data });
 }

--- a/tests/advocates.spec.ts
+++ b/tests/advocates.spec.ts
@@ -8,7 +8,9 @@ test('viewing advocates', async ({ page }) => {
   await expect(page.getByText("Jane").first()).toBeVisible();
 
   // verify all relevant information is present
-  const johnDoeRow = await page.locator('tr', {has: page.getByText('John').first()});
+  const johnDoeRow = await page.locator('tr').first();
+
+  await expect(johnDoeRow).toBeVisible();
   await expect(johnDoeRow.getByText("Doe")).toBeVisible();
   await expect(johnDoeRow.getByText("New York")).toBeVisible();
   await expect(johnDoeRow.getByText("Suicide History/Attempts")).toBeVisible();

--- a/tests/advocates.spec.ts
+++ b/tests/advocates.spec.ts
@@ -8,7 +8,7 @@ test('viewing advocates', async ({ page }) => {
   await expect(page.getByText("Jane").first()).toBeVisible();
 
   // verify all relevant information is present
-  const johnDoeRow = await page.locator('tr').first();
+  const johnDoeRow = await page.locator('tr', {has: page.getByText('John')}).first();
 
   await expect(johnDoeRow).toBeVisible();
   await expect(johnDoeRow.getByText("Doe")).toBeVisible();


### PR DESCRIPTION
Swaps out the fake data source for the real database source. Having a way to use fake, consistent data is actually really useful and a later PR may reintroduce this in a more flexible way.