### PR TITLE
feat: improve filtering

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChangeEventHandler, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import type { Advocate } from '../db/schema';
 
 export default function Home() {
@@ -21,6 +21,11 @@ export default function Home() {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const searchTerm = e.target.value;
 
+    const includesInsensitive = (a: string) => {
+      return a.toLowerCase().includes(searchTerm.toLowerCase());
+    }
+
+
     // TODO: we should not be doing this in react - will fix in follow up PR
     const searchTermEl = document.getElementById("search-term");
     if (searchTermEl) {
@@ -29,13 +34,15 @@ export default function Home() {
 
     console.log("filtering advocates...");
     const filteredAdvocates = advocates.filter((advocate) => {
+      // TODO: this should be filtered at the database level as this wouldn't scale with more than a few advocates
       return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.toString(10).includes(searchTerm)
+        includesInsensitive(advocate.firstName) ||
+        includesInsensitive(advocate.lastName) ||
+        includesInsensitive(advocate.city) ||
+        includesInsensitive(advocate.degree) ||
+        advocate.specialties.map(s => s.toLowerCase()).includes(searchTerm.toLowerCase()) ||
+        advocate.yearsOfExperience.toString().includes(searchTerm) ||
+        advocate.phoneNumber.toString().includes(searchTerm)
       );
     });
 
@@ -53,11 +60,11 @@ export default function Home() {
       <br />
       <br />
       <div>
-        <p>Search</p>
+        <label htmlFor="search">Search</label>
         <p>
           Searching for: <span id="search-term"></span>
         </p>
-        <input style={{ border: "1px solid black" }} onChange={onChange} />
+        <input name="search" style={{ border: "1px solid black" }} onChange={onChange} type="text" role="searchbox"/>
         <button onClick={onClick}>Reset Search</button>
       </div>
       <br />

--- a/tests/advocates.spec.ts
+++ b/tests/advocates.spec.ts
@@ -1,20 +1,82 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
+
+class AdvocatesPage {
+  page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto("/");
+    await expect(this.page.getByText("Solace Advocates")).toBeVisible();
+  }
+
+  async getAdvocateRowByText(text: string) {
+    return this.page.locator('tr', {has: this.page.getByText(text)}).first();
+  }
+
+  async searchAdvocates(text: string) {
+    return this.page.getByRole("searchbox").fill(text);
+  }
+}
 
 test('viewing advocates', async ({ page }) => {
-  await page.goto("/");
-
-  await expect(page.getByText("Solace Advocates")).toBeVisible();
-  await expect(page.getByText("John").first()).toBeVisible();
-  await expect(page.getByText("Jane").first()).toBeVisible();
+  const advocatesPage = new AdvocatesPage(page);
+  await advocatesPage.goto();
 
   // verify all relevant information is present
-  const johnDoeRow = await page.locator('tr', {has: page.getByText('John')}).first();
+  const johnDoeRow = await advocatesPage.getAdvocateRowByText('John');
+  const janeDoeRow = await advocatesPage.getAdvocateRowByText('Jane');
 
   await expect(johnDoeRow).toBeVisible();
+  await expect(janeDoeRow).toBeVisible();
+
   await expect(johnDoeRow.getByText("Doe")).toBeVisible();
   await expect(johnDoeRow.getByText("New York")).toBeVisible();
   await expect(johnDoeRow.getByText("Suicide History/Attempts")).toBeVisible();
   await expect(johnDoeRow.getByText("Personality disorders")).toBeVisible();
   await expect(johnDoeRow.getByText("10")).toBeVisible();
   await expect(johnDoeRow.getByText("5551234567")).toBeVisible();
+});
+
+test('filtering advocates', async ({ page }) => {
+  const advocatesPage = new AdvocatesPage(page);
+  await advocatesPage.goto();
+
+  // verify all relevant information is present
+  let johnDoeRow = await advocatesPage.getAdvocateRowByText('John');
+  let janeDoeRow = await advocatesPage.getAdvocateRowByText('Jane');
+
+  await expect(johnDoeRow).toBeVisible();
+  await expect(janeDoeRow).toBeVisible();
+
+  await advocatesPage.searchAdvocates('Jane');
+
+  johnDoeRow = await advocatesPage.getAdvocateRowByText('John');
+  janeDoeRow = await advocatesPage.getAdvocateRowByText('Jane');
+
+  await expect(johnDoeRow).not.toBeVisible();
+  await expect(janeDoeRow).toBeVisible();
+
+});
+
+test('filtering advocates is case insensitive', async ({ page }) => {
+  const advocatesPage = new AdvocatesPage(page);
+  await advocatesPage.goto();
+
+  // verify all relevant information is present
+  let johnDoeRow = await advocatesPage.getAdvocateRowByText('John');
+  let janeDoeRow = await advocatesPage.getAdvocateRowByText('Jane');
+
+  await expect(johnDoeRow).toBeVisible();
+  await expect(janeDoeRow).toBeVisible();
+
+  await advocatesPage.searchAdvocates('jane');
+
+  johnDoeRow = await advocatesPage.getAdvocateRowByText('John');
+  janeDoeRow = await advocatesPage.getAdvocateRowByText('Jane');
+
+  await expect(johnDoeRow).not.toBeVisible();
+  await expect(janeDoeRow).toBeVisible();
 });


### PR DESCRIPTION
This improves the frontend filtering and creates tests to ensure filtering works for a couple base cases. These tests are not comprehensive - ideally unit or integration tests would test more cases such as filtering by all applicable fields. Filtering by all filterable columns in an E2E test can end up being slow and flakey - so there are trade offs here.

This also introduces a new test pattern for reusing functionality between tests and make refactoring the page a little easier.