### PR TITLE
feat: move filtering to the backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "drizzle-orm": "^0.32.1",
+        "lodash": "^4.17.21",
         "next": "^14.2.19",
         "postgres": "^3.4.4",
         "react": "^18.3.1",
@@ -16,6 +17,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.52.0",
+        "@types/lodash": "^4.17.16",
         "@types/node": "^20.14.12",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -1260,6 +1262,13 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.17.9",
@@ -4025,6 +4034,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.32.1",
+    "lodash": "^4.17.21",
     "next": "^14.2.19",
     "postgres": "^3.4.4",
     "react": "^18.3.1",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",
+    "@types/lodash": "^4.17.16",
     "@types/node": "^20.14.12",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -6,7 +6,6 @@ import { NextApiRequest } from "next";
 export async function GET(req: NextApiRequest) {
   let searchTerm: string | null = null;
   const url = new URL(req.url!);
-  console.log(url)
 
   if (url.searchParams.has('search')) {
     searchTerm = url.searchParams.get('search');
@@ -17,7 +16,6 @@ export async function GET(req: NextApiRequest) {
 
   let data;
   if (searchTerm) {
-    console.log("using search term", searchTerm)
     data = await db.select().from(advocates).where(or(
       ilike(advocates.firstName, `%${searchTerm}%`),
       ilike(advocates.lastName, `%${searchTerm}%`),

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,8 +1,33 @@
+import { ilike, or } from "drizzle-orm";
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
+import { NextApiRequest } from "next";
 
-export async function GET() {
-  const data = await db.select().from(advocates);
+export async function GET(req: NextApiRequest) {
+  let searchTerm: string | null = null;
+  const url = new URL(req.url!);
+  console.log(url)
+
+  if (url.searchParams.has('search')) {
+    searchTerm = url.searchParams.get('search');
+    if (Array.isArray(searchTerm)) {
+      return Response.json({error: 'search must be a string'}, {status: 400});
+    }
+  }
+
+  let data;
+  if (searchTerm) {
+    console.log("using search term", searchTerm)
+    data = await db.select().from(advocates).where(or(
+      ilike(advocates.firstName, `%${searchTerm}%`),
+      ilike(advocates.lastName, `%${searchTerm}%`),
+      ilike(advocates.city, `%${searchTerm}%`),
+      ilike(advocates.degree, `%${searchTerm}%`),
+      // TODO: support specialities, yoe, and phone numbers
+    ));
+  } else {
+    data = await db.select().from(advocates)
+  }
 
   return Response.json({ data });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import type { Advocate } from "../db/schema";
 
 const useAdvocates = () => {
   const [advocates, setAdvocates] = useState<Advocate[]>([]);
+  const searchRef = useRef<HTMLInputElement | null>(null);
 
   const getAdvocates = async (search: string | null = null) => {
     const abortControlller = new AbortController();
@@ -39,14 +40,18 @@ const useAdvocates = () => {
   }
 
   const resetSearch = () => {
+    if (searchRef.current) {
+      searchRef.current.value = "";
+    }
+
     getAdvocates();
   }
 
-  return {advocates, onSearch, resetSearch};
+  return {advocates, onSearch, resetSearch, searchRef };
 }
 
 export default function Home() {
-  const {advocates, onSearch, resetSearch} = useAdvocates();
+  const {advocates, onSearch, resetSearch, searchRef} = useAdvocates();
 
   return (
     <main style={{ margin: "24px" }}>
@@ -61,6 +66,7 @@ export default function Home() {
           onChange={onSearch}
           type="text"
           role="searchbox"
+          ref={searchRef}
         />
         <button onClick={resetSearch}>Reset Search</button>
       </div>

--- a/tests/advocates.spec.ts
+++ b/tests/advocates.spec.ts
@@ -93,8 +93,10 @@ test('resetting the filter', async ({page}) => {
   const advocatesPage = new AdvocatesPage(page);
   await advocatesPage.goto();
 
+  const promise = page.waitForResponse('/api/advocates');
   await advocatesPage.searchAdvocates('Nonsense Value That Wont Show Up');
-  await expect(await advocatesPage.getAllRows()).not.toBeVisible();
+  await promise;
+  await expect(await advocatesPage.getAdvocateRowByText('John')).not.toBeVisible();
 
   await advocatesPage.resetSearch();
   await expect(await advocatesPage.getAdvocateRowByText('John')).toBeVisible();

--- a/tests/advocates.spec.ts
+++ b/tests/advocates.spec.ts
@@ -16,6 +16,10 @@ class AdvocatesPage {
     return this.page.locator('tr', {has: this.page.getByText(text)}).first();
   }
 
+  async getSearchValue() {
+    return this.page.getByRole("searchbox").inputValue();
+  }
+
   async searchAdvocates(text: string) {
     return this.page.getByRole("searchbox").fill(text);
   }
@@ -100,4 +104,5 @@ test('resetting the filter', async ({page}) => {
 
   await advocatesPage.resetSearch();
   await expect(await advocatesPage.getAdvocateRowByText('John')).toBeVisible();
+  await expect(await advocatesPage.getSearchValue()).toBe("");
 });


### PR DESCRIPTION
This moves the searching logic to the database. It also encapsulates the logic for getting advocates into a hook. This hook allows us to encapsulate the behavior of the component without polluting the logic for presenting the data in the view.

A couple important things this also adds:
* it debounces the search so that we don't hammer the backend on a user typing
* it uses a ref to clear the search box on reset. Using a ref over useState keeps component renders to a minimum and simplifies the logic. This keeps the component responsive. 
* It introduces an abort controller into the fetch call so that we can abort a call if we unrender or make another query. This prevents race conditions on updating the data.

Note: in the real world, we'd probably want to use a form library and server side data fetching library because managing both of these are complex and hard to get right.